### PR TITLE
feat(vdom-manipulations): [CH4] mount dom, destroy dom, setting and removing attributes and events

### DIFF
--- a/packages/runtime/src/attributes.js
+++ b/packages/runtime/src/attributes.js
@@ -1,0 +1,52 @@
+export function setAttributes(el, attrs) {
+    const {class: className, style, ...otherAttrs} = attrs;
+
+    if (className) {
+        setClass(el, className);
+    }
+
+    if (style) {
+        Object.entries(style).forEach(([prop, value]) => {
+            setStyle(el, prop, value);
+        })
+    }
+
+    for (const [name, value] of Object.entries(otherAttrs)) {
+        setAttributes(el, name, value);
+    }
+}
+
+function setClass(el, className) {
+    el.className = '';
+
+    if (typeof className === 'string') {
+        el.className = className;
+    }
+
+    if (Array.isArray(className)) {
+        el.classList.add(...className);
+    }
+}
+
+export function setStyle(el, name, value) {
+    el.style[name] = value;
+}
+
+export function removeStyle(el, name) {
+    el.style[name] = null;
+}
+
+export function setAttribute(el, name, value) {
+    if (value == null) {
+        removeAttribute(el, name);
+    } else if (name.startsWith('data-')) {
+        el.setAttribute(name, value);
+    } else {
+        el[name] = value;
+    }
+}
+
+export function removeAttribute(el, name) {
+    el[name] = null;
+    el.removeAttribute(name);
+}

--- a/packages/runtime/src/destroy-dom.js
+++ b/packages/runtime/src/destroy-dom.js
@@ -1,0 +1,52 @@
+import {DOM_TYPES} from './h';
+import {removeEventListeners} from './events'
+
+export function destroyDOM(vdom) {
+    const {type} = vdom;
+
+    switch (type) {
+        case DOM_TYPES.TEXT: {
+            removeTextNode(vdom);
+            break;
+        }
+
+        case DOM_TYPES.ELEMENT: {
+            removeElementNode(vdom);
+            break;
+        }
+
+        case DOM_TYPES.FRAGMENT: {
+            removeFragmentNode(vdom);
+            break;
+        }
+
+        default: {
+            throw new Error(`Unknown DOM type: ${type}`);
+        }
+    }
+
+    delete vdom.el;
+}
+
+function removeTextNode(vdom) {
+    const {el} = vdom;
+    el.remove();
+}
+
+function removeElementNode(vdom) {
+    const {el, children, listeners} = vdom;
+
+    el.remove();
+    children.forEach(destroyDOM);
+
+    if (listeners) {
+        removeEventListeners(listeners, el);
+        delete vdom.listeners;
+    }
+
+}
+
+function removeFragmentNode(vdom) {
+    const {children} = vdom;
+    children.forEach(destroyDOM);
+}

--- a/packages/runtime/src/events.js
+++ b/packages/runtime/src/events.js
@@ -1,0 +1,15 @@
+export function addEventListener(eventName, handler, el) {
+    el.addEventListener(eventName, handler);
+    return handler;
+}
+
+export function addEventListeners(listeners = {}, el) {
+    const addedListeners = {};
+
+    Object.entries(listeners).forEach(([eventName, handler]) => {
+        const listener = addEventListener(eventName, handler, el);
+        addedListeners[eventName] = listener;
+    });
+
+    return addedListeners;
+}

--- a/packages/runtime/src/events.js
+++ b/packages/runtime/src/events.js
@@ -13,3 +13,9 @@ export function addEventListeners(listeners = {}, el) {
 
     return addedListeners;
 }
+
+export function removeEventListeners(listeners = {}, el) {
+    Object.entries(listeners).forEach(([eventName, handler]) => {
+        el.removeEventListener(eventName, handler);
+    })
+}

--- a/packages/runtime/src/mount-dom.js
+++ b/packages/runtime/src/mount-dom.js
@@ -1,0 +1,54 @@
+import { DOM_TYPES } from "./h";
+
+export function mountDom(vdom, parentEl) {
+    switch (vdom.type) {
+        case DOM_TYPES.TEXT: {
+            createTextNode(vdom, parentEl);
+            break;
+        };
+        case DOM_TYPES.ELEMENT: {
+            createElementNode(vdom, parentEl);
+            break;
+        };
+        case DOM_TYPES.FRAGMENT: {
+            createFragmentNodes(vdom, parentEl);
+            break;
+        };
+        default: {
+            throw new Error(`Unknown DOM type: ${vdom.type}`);
+        }
+    }
+}
+
+function createTextNode(vdom, parentEl) {
+    const {value} = vdom;
+
+    const textNode = document.createTextNode(value);
+    vdom.el = textNode;
+
+    parentEl.append(textNode);
+}
+
+function createElementNode(vdom, parentEl) {
+    const {tag, props, children} = vdom;
+
+    const element = document.createElement(tag);
+    addProps(element, props, vdom);
+    vdom.el = element;
+
+    children.forEach((child) => mountDom(child, element));
+    parentEl.append(element)
+}
+
+function createFragmentNodes(vdom, parentEl) {
+    const {children} = vdom;
+    vdom.el = parentEl;
+    children.forEach((child) => mountDom(child, parentEl));
+}
+
+function addProps(el, props, vdom) {
+    const {on: events, ...attrs} = props;
+
+    vdom.listeners = addEventListeners(events, el);
+    setAttributes(el, attrs);
+}


### PR DESCRIPTION
This commit contains a basic version of mounting and destroying DOM. 

As well as setting and removing:
- Nodes (Text, Element, Fragment)
- Attributes (classes, styles and other)
- Events